### PR TITLE
Pass kwargs to json.dumps in singer.format_message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name="singer-python",
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       url="http://singer.io",
       install_requires=[
-          'pytz==2018.4',
+          'pytz>=2019.1',
           'jsonschema>=2.6.0',
           'simplejson>=3.16.0',
           'python-dateutil>=2.6.0',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name="singer-python",
       install_requires=[
           'pytz==2018.4',
           'jsonschema==2.6.0',
-          'simplejson==3.11.1',
+          'simplejson>=3.16.0',
           'python-dateutil>=2.6.0',
           'backoff==1.3.2',
       ],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name="singer-python",
       url="http://singer.io",
       install_requires=[
           'pytz==2018.4',
-          'jsonschema==2.6.0',
+          'jsonschema>=2.6.0',
           'simplejson>=3.16.0',
           'python-dateutil>=2.6.0',
           'backoff==1.3.2',

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -209,8 +209,10 @@ def parse_message(msg):
         return None
 
 
-def format_message(message):
-    return json.dumps(message.asdict(), use_decimal=True)
+def format_message(message, **kwargs):
+    return json.dumps(message.asdict(),
+                      use_decimal=kwargs.pop('use_decimal', True),
+                      **kwargs)
 
 
 def write_message(message):


### PR DESCRIPTION
Allow configuring json encoder by passing kwargs through
to json.dumps in singer.format_message. Use case is passing data
from pandas.DataFrame containing NaN to encode as `null`